### PR TITLE
More errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ All available options:
 ```js
 require('proxyproto').createServer(server, {
   setNoDelay: true, // diable nagle algorithm
+  handleCommonErrors: false, // handle common socket errors (default: true)
   onError: err => log.error(err) // error handler for servers and sockets
 });
 ```

--- a/index.js
+++ b/index.js
@@ -18,13 +18,13 @@ const createServer = (server, options) => {
       if (err && err.code === 'ECONNRESET') {
         return console.log(`${source} Connection interrupted`);
       } else if (error.includes('peer did not return a certificate')) {
-        return console.log('Connection dropped - Client certificate required but not presented');
+        return console.log(`${source} Connection dropped - Client certificate required but not presented`);
       } else if (error.includes('inappropriate fallback') ||
                  error.includes('version too low') ||
                  error.includes('no shared cipher')) {
-        return console.log('Connection dropped - Client used insecure cipher');
+        return console.log(`${source} Connection dropped - Client used insecure cipher`);
       } else if (error.includes('unknown protocol')) {
-        return console.log('Connection dropped - Client used unknown protocol');
+        return console.log(`${source} Connection dropped - Client used unknown protocol`);
       }
     }
     if (options.onError) {

--- a/index.js
+++ b/index.js
@@ -10,10 +10,13 @@ const createServer = (server, options) => {
     throw new Error('Missing server argument - http.createServer(), https, net, tls, etc');
   }
   options = options || {};
+  if (!options.hasOwnProperty('handleCommonErrors')) {
+    options.handleCommonErrors = true;
+  }
 
   function onError(err, source) {
     // handle common socket errors
-    if (!options.allErrors) {
+    if (options.handleCommonErrors) {
       const error = String(err);
       if (err && err.code === 'ECONNRESET') {
         return console.log(`${source} Connection interrupted`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxyproto",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pre-process PROXY protocol headers from node tcp connections",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- add error handlers to all streams
- handle common socket errors
- include source stream in error handler

Streams changed recently ( https://github.com/nodejs/node/pull/18438 ) in node 10 to not end gracefully on error events. To avoid fatal errors, error handlers are added to all relevant streams. Common socket errors are handled to avoid unnecessary errors