### PR TITLE
Add load testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,8 @@ const createServer = (server, options) => {
         const details = parser.decode(data.slice(0,proxyProtoLength));
         ['remoteAddress','remotePort'].forEach(property => {
           Object.defineProperty(socket, property, {
-              get: () => details[property]
+              get: () => details[property],
+              configurable: true
             });
         });
         data = data.slice(proxyProtoLength);
@@ -92,7 +93,8 @@ const createServer = (server, options) => {
     server.on('secureConnection', socket => {
       ['remoteAddress','remotePort'].forEach(property => {
         Object.defineProperty(socket, property, {
-            get: () => socket._parent[property]
+            get: () => socket._parent[property],
+            configurable: true
           });
         });
       socket.addListener('error', err => onError(err, 'secure socket'));

--- a/index.js
+++ b/index.js
@@ -19,9 +19,9 @@ const createServer = (server, options) => {
     if (options.handleCommonErrors) {
       const error = String(err);
       if (err && err.code === 'ECONNRESET') {
-        return console.log(`${source} Connection interrupted`);
+        return;
       } else if (error.includes('SSL routines')) {
-        return console.log(`${source} Connection dropped - ssl routines failed: ${error}`);
+        return;
       }
     }
     if (options.onError) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "proxy-protocol-v2": "1.0.0-dev-81558e614b7b74d65747e240365e573becdd8c73"
   },
   "devDependencies": {
+    "autocannon": "^3.2.1",
     "pem": "^1.14.2",
     "tap": "^12.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxyproto",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Pre-process PROXY protocol headers from node tcp sockets",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Uses  `autocannon` for load testing
- Ensure no funky connection issues - only `200` status codes
- Quiet common errors
- Fix "Cannot redefine property: remoteAddress"