### PR TITLE
All the errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ const createServer = (server, options) => {
       }
     });
   } else {
-   server.on('socket', socket => {
+   server.on('connection', socket => {
      socket.addListener('error', err => onError(err, 'socket'));
    });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxyproto",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Pre-process PROXY protocol headers from node tcp sockets",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Listen for the correct event named `connection`, otherwise errors on the main server socket were not being caught