### PR TITLE
Asynchronous listen

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,12 @@ const createServer = (server, options) => {
     throw err;
   }
 
+  function listen(proxy, server) {
+    const port = server.address().port;
+    server.close();
+    proxied.listen(port, () => console.log(`PROXY protocol parser listening to port ${port}`));
+  }
+
   // create proxy protocol processing server
   const proxied = require('net').createServer(socket => {
     const buf = [];
@@ -111,11 +117,11 @@ const createServer = (server, options) => {
    });
   }
 
+  // listen to listening event
+  server.on('listening', () => listen(proxied, server));
   // if server is already listening, use that port
   if (server.listening) {
-    const port = server.address().port;
-    server.close();
-    proxied.listen(port, () => console.log(`PROXY protocol parser listening to port ${port}`));
+    listen(proxied, server);
   }
 
   return proxied;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxyproto",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Pre-process PROXY protocol headers from node tcp sockets",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If provided server is not already listening, it could be in the middle of an asynchronous system call to acquire the port. For more info see https://nodejs.org/api/net.html#net_server_listen

This PR handles situations where the listen function takes longer than anticipated by adding a listener for the `listening` event